### PR TITLE
Bug fixed (initWithData:)

### DIFF
--- a/OLImage.m
+++ b/OLImage.m
@@ -152,7 +152,7 @@ inline static BOOL CGImageSourceGetFramesAndDurations(NSTimeInterval *finalDurat
     if (imageSource) {
         NSTimeInterval *aFinalDuration = NULL;
         NSUInteger numberOfFrames = CGImageSourceGetCount(imageSource);
-        
+        self.frameDurations = (NSTimeInterval *) malloc(numberOfFrames  * sizeof(NSTimeInterval));
         self.images = [NSMutableArray arrayWithCapacity:numberOfFrames];
         CGImageSourceGetFramesAndDurations(aFinalDuration, self.frameDurations, self.images, imageSource);
         if (aFinalDuration) {


### PR DESCRIPTION
initWithData: didn't initialize frameDurations, this will lead to
EXC_BAD_ACCESS
