### PR TITLE
AFImageRequestOperation category improvement

### DIFF
--- a/Categories/AFImageRequestOperation+OLImage.m
+++ b/Categories/AFImageRequestOperation+OLImage.m
@@ -10,37 +10,16 @@
 #import <objc/runtime.h>
 #import "OLImage.h"
 
-static char kAFImageObjectKey;
-
-@interface AFImageRequestOperation (_OLImage)
-
-@property (nonatomic, strong, getter = ol_responseImage, setter = ol_setResponseImage:) UIImage *ol_responseImage;
-
-@end
-
-@implementation AFImageRequestOperation (_OLImage)
-
-@dynamic ol_responseImage;
-
-- (UIImage *)ol_responseImage {
-    return (UIImage *)objc_getAssociatedObject(self, &kAFImageObjectKey);
-}
-
-- (void)ol_setResponseImage:(UIImage *)image {
-    objc_setAssociatedObject(self, &kAFImageObjectKey, image, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-}
-
-@end
-
 @implementation AFImageRequestOperation (OLImage)
 
-- (UIImage *)responseImage {
-    if (![self ol_responseImage] && [self.responseData length] > 0 && [self isFinished]) {
-        UIImage *image = [OLImage imageWithData:self.responseData];
-        self.ol_responseImage = image;
+- (void)setResponseOLImage:(UIImage *)responseImage {
+    if ([self.responseData length] > 0 && [self isFinished]) {
+        [self setResponseOLImage:[OLImage imageWithData:self.responseData]];
     }
-    
-    return self.ol_responseImage;
+}
+
++ (void)load {
+    method_exchangeImplementations(class_getInstanceMethod(self, @selector(setResponseImage:)), class_getInstanceMethod(self, @selector(setResponseOLImage:)));
 }
 
 @end


### PR DESCRIPTION
This change removes the extra OLImage AssociatedObject used in the resposeImage getter, and instead modifying the setter. Thus, removing the additional the memory required to store both the normal UIImage and the OLImage AssociatedObject.

Please let me know if you have any questions about the code. Method swizzling can be quite confusing.
