### PR TITLE
Fix to make setting an OLImageView's view property to nil clear the image correctly

### DIFF
--- a/OLImageView.m
+++ b/OLImageView.m
@@ -85,6 +85,9 @@ const NSTimeInterval kMaxTimeStep = 1; // note: To avoid spiral-o-death
         [self startAnimating];
     } else {
         [super setImage:image];
+        //DMC: If the new image is nil, remove the layer contents so the image view on-screen goes blank.
+        if (image == nil)
+            self.layer.contents = nil;
     }
 }
 


### PR DESCRIPTION
...contents were not being cleared, so the old image was still visible.

With this fix, if you set the image property to nil, the image view contents are cleared.
