### PR TITLE
Made sizeThatFits: & thus sizeToFit work

### DIFF
--- a/OLImageView.m
+++ b/OLImageView.m
@@ -186,4 +186,9 @@ const NSTimeInterval kMaxTimeStep = 1; // note: To avoid spiral-o-death
     return self.animatedImage ?: [super image];
 }
 
+- (CGSize)sizeThatFits:(CGSize)size
+{
+    return self.image.size;
+}
+
 @end


### PR DESCRIPTION
Before this change OLImageView would return CGSizeZero when calling sizeThatFits:

From [UIView's documentation](http://developer.apple.com/library/ios/#documentation/UIKit/Reference/UIView_Class/UIView/UIView.html#//apple_ref/occ/instm/UIView/sizeThatFits:) for sizeThatFits: "UIImageView object returns the size of the image it is currently displaying"
