### PR TITLE
Extracted the "Core" subpec.

### DIFF
--- a/OLImageView.podspec
+++ b/OLImageView.podspec
@@ -7,15 +7,17 @@ Pod::Spec.new do |s|
   s.author       = { "Diego Torres" => "contact@dtorres.me" }
   s.source       = { :git => "https://github.com/ondalabs/OLImageView.git", :tag => s.version.to_s }
   s.platform     = :ios, '5.0'
-  s.source_files = 'OLImage.{h,m}', 'OLImageView.{h,m}'
   s.framework  = 'ImageIO', 'MobileCoreServices', 'QuartzCore'
   s.requires_arc = true
-    
+
+  s.subspec 'Core' do |core|    
+    core.source_files = 'OLImage.{h,m}', 'OLImageView.{h,m}'
+  end
+
   s.subspec 'AFNetworking' do |af|
+    af.dependency 'OLImageView/Core'
     af.dependency 'AFNetworking'
     af.source_files = "Categories/AFImageRequestOperation+OLImage.{h,m}"
   end
-  
-  s.preferred_dependency = 'AFNetworking'
 
 end


### PR DESCRIPTION
You can now use `pod 'OLImageView/Core'` when you don't need AFNetworking.
