### PR TITLE
Use a blank UIImage instead of NSNull as an NSArray placeholder

### DIFF
--- a/OLImage.m
+++ b/OLImage.m
@@ -165,9 +165,9 @@ inline static BOOL isRetinaFilePath(NSString *path)
     self.loopCount = [gifProperties[(NSString *)kCGImagePropertyGIFLoopCount] unsignedIntegerValue];
     self.images = [NSMutableArray arrayWithCapacity:numberOfFrames];
     
-    NSNull *aNull = [NSNull null];
+    UIImage *placeholderImage = [UIImage new];
     for (NSUInteger i = 0; i < numberOfFrames; ++i) {
-        [self.images addObject:aNull];
+        [self.images addObject:placeholderImage];
         NSTimeInterval frameDuration = CGImageSourceGetGifFrameDelay(imageSource, i);
         self.frameDurations[i] = frameDuration;
         self.totalDuration += frameDuration;


### PR DESCRIPTION
This fixes a crash caused by sending the CGImage message to NSNull. This scenario occurs when the frame to be displayed on the UI thread hasn't completed decoding on the background thread.
