### PR TITLE
Fix image scaling issue of AFNetworking category.

### DIFF
--- a/Categories/AFImageRequestOperation+OLImage.m
+++ b/Categories/AFImageRequestOperation+OLImage.m
@@ -14,7 +14,7 @@
 
 - (void)setResponseOLImage:(UIImage *)responseImage {
     if ([self.responseData length] > 0 && [self isFinished]) {
-        [self setResponseOLImage:[OLImage imageWithData:self.responseData]];
+        [self setResponseOLImage:[OLImage imageWithData:self.responseData scale:self.imageScale]];
     }
 }
 


### PR DESCRIPTION
When downloading an image of scale value other than 1.0 with AFNetworking, imageWithData: method will always set scale value to 1.0.
