### PR TITLE
Added OLImageResponseSerializer for AFNetworking 2.0+

### DIFF
--- a/OLImageView.podspec
+++ b/OLImageView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "OLImageView"
-  s.version      = "1.2.0"
+  s.version      = "1.3.2"
   s.summary      = "Animated GIFs implemented the right way."
   s.homepage     = "https://www.github.com/ondalabs/OLImageView"
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
@@ -9,15 +9,22 @@ Pod::Spec.new do |s|
   s.platform     = :ios, '5.0'
   s.framework  = 'ImageIO', 'MobileCoreServices', 'QuartzCore'
   s.requires_arc = true
+  s.default_subspec = 'Core'
 
-  s.subspec 'Core' do |core|    
+  s.subspec 'Core' do |core|
     core.source_files = 'OLImage.{h,m}', 'OLImageView.{h,m}'
   end
 
   s.subspec 'AFNetworking' do |af|
     af.dependency 'OLImageView/Core'
-    af.dependency 'AFNetworking'
+    af.dependency 'AFNetworking', '~> 1.0'
     af.source_files = "Categories/AFImageRequestOperation+OLImage.{h,m}"
   end
 
+  s.subspec 'AFNetworking2' do |ss|
+    s.platform = :ios, '6.0'
+    ss.dependency 'OLImageView/Core'
+    ss.dependency 'AFNetworking', '~> 2.0'
+    ss.source_files = "Optional/OLImageResponseSerializer.{h,m}"
+  end
 end

--- a/Optional/OLImageResponseSerializer.h
+++ b/Optional/OLImageResponseSerializer.h
@@ -1,0 +1,14 @@
+//
+//  OLImageResponseSerializer.h
+//  OLImageViewDemo
+//
+//  Created by Romans Karpelcevs on 29/05/14.
+//  Copyright (c) 2014 Onda Labs. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <AFURLResponseSerialization.h>
+
+@interface OLImageResponseSerializer : AFImageResponseSerializer
+
+@end

--- a/Optional/OLImageResponseSerializer.m
+++ b/Optional/OLImageResponseSerializer.m
@@ -1,0 +1,21 @@
+//
+//  OLImageResponseSerializer.m
+//  OLImageViewDemo
+//
+//  Created by Romans Karpelcevs on 29/05/14.
+//  Copyright (c) 2014 Onda Labs. All rights reserved.
+//
+
+#import "OLImageResponseSerializer.h"
+#import "OLImage.h"
+
+@implementation OLImageResponseSerializer
+
+- (id)responseObjectForResponse:(NSURLResponse *)response
+                           data:(NSData *)data
+                          error:(NSError *__autoreleasing *)error
+{
+    return [OLImage imageWithData:data];
+}
+
+@end


### PR DESCRIPTION
I added response serializer for the image to great OLImage instances.
No `data` or `isFinished` checks are added because `AFNetworking` calls this when call is finished and data is checked for `nil` inside the `imageWithData:` code.

I also updated podspec, but it will not work until the new build is tagged. I don't know what's the correct way to update podspec when adding new files.
