### PR TITLE
Adds @3x support

### DIFF
--- a/OLImage.m
+++ b/OLImage.m
@@ -131,7 +131,14 @@ inline static BOOL isRetinaFilePath(NSString *path)
     
     // If no retina suffix present, we try to append the appropriate one
     if (!isRetinaFilePath(path)) {
-        NSString *suffix = [NSString stringWithFormat:@"@%gx", [UIScreen mainScreen].nativeScale];
+        
+        CGFloat scale = [UIScreen mainScreen].scale;
+        
+        if ([[UIScreen mainScreen] respondsToSelector:@selector(nativeScale)]) {
+            scale = [UIScreen mainScreen].nativeScale; //This property returns @3x
+        }
+        
+        NSString *suffix = [NSString stringWithFormat:@"@%gx", scale];
         
         NSMutableString *retinaPath = [path mutableCopy];
         


### PR DESCRIPTION
Because @3x is something we'll all need now.
I've also added automatic path extension support and retina suffix.

This 3 examples will import the same image:
`[OLImage imageNamed:@"file@3x.gif"]`
`[OLImage imageNamed:@"file@3x"]`
`[OLImage imageNamed:@"file"]`

Makes working with OLImageView a lot more fun!
